### PR TITLE
Setup github pages for hosting

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,47 @@
+name: Deploy static site to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Prepare site directory
+        run: |
+          set -euo pipefail
+          mkdir -p site
+          cp -r index.html css js site/
+          if [ -f test-audio.html ]; then cp -r test-audio.html site/; fi
+          # Prevent Jekyll processing
+          touch site/.nojekyll
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+

--- a/README.md
+++ b/README.md
@@ -210,3 +210,28 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 ---
 
 **superfreq** - Where audio production meets puzzle gaming! 🎵🧩
+
+### 🌐 Deploying to GitHub Pages
+
+- **Prerequisites**
+  - A GitHub repository with this code on the `main` branch
+  - GitHub Actions enabled for the repository
+
+- **Enable Pages**
+  - Go to Settings → Pages
+  - Set "Build and deployment" → "Source" to "GitHub Actions"
+
+- **Workflow**
+  - A workflow is already included at `.github/workflows/pages.yml`
+  - On push to `main`, it uploads `index.html`, `css/`, `js/`, and `test-audio.html` to Pages
+  - It also adds `.nojekyll` so files are served as-is
+
+- **First Deploy**
+  - Push to `main`
+  - Check Actions tab for the "Deploy static site to GitHub Pages" run
+  - When complete, the Pages URL appears in the job summary and under Settings → Pages
+
+- **Custom Domain (Optional)**
+  - Add your domain in Settings → Pages → Custom domain
+  - Create a `CNAME` record at your DNS pointing to `<username>.github.io`
+  - If you want to pin the domain in the repo, create a `CNAME` file at the site root containing your domain (e.g., `example.com`)


### PR DESCRIPTION
Add GitHub Actions workflow and README instructions to deploy the static site to GitHub Pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-f9718a4e-9141-460b-aafe-e47ca251439c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f9718a4e-9141-460b-aafe-e47ca251439c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

