### PR TITLE
Improve sample selection for flexible file uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,52 @@ python -m http.server 8000
 npx serve .
 ```
 
+## Configuration
+
+By default, assets are loaded relatively from the `audio/` folder. You can set a CDN base:
+
+```html
+<script>
+  window.APP_CONFIG = {
+    CDN_BASE_URL: 'https://cdn.example.com/project'
+  };
+  // Optional overrides
+  // SAMPLES_MANIFEST_URL defaults to `${CDN_BASE_URL}/audio/samples/manifest.json`
+  // SAMPLES_FOLDER_URL defaults to `${CDN_BASE_URL}/audio/samples/`
+  // window.APP_CONFIG.SAMPLES_MANIFEST_URL = 'https://cdn.example.com/project/audio/samples/manifest.json';
+  // window.APP_CONFIG.SAMPLES_FOLDER_URL = 'https://cdn.example.com/project/audio/samples/';
+  // Add this before js/config.js is loaded
+  </script>
+```
+
+### Samples Manifest (recommended)
+
+Place a `manifest.json` file in your samples folder and list audio files. Filenames can be anything.
+
+Accepted formats:
+
+```json
+[
+  "kit1/kick.wav",
+  "kit1/snare.wav",
+  "vocals/take-a.mp3"
+]
+```
+
+or
+
+```json
+{
+  "files": [
+    "kit1/kick.wav",
+    "kit1/snare.wav",
+    "vocals/take-a.mp3"
+  ]
+}
+```
+
+The game deterministically picks a daily sample from the manifest without requiring dates in filenames. If the manifest is missing or empty, the game falls back to dev sample names and will synthesize test audio if files are unavailable.
+
 ## 🐛 GitHub Issues Management
 
 Manage GitHub issues directly from your local machine using the included script:

--- a/js/config.js
+++ b/js/config.js
@@ -10,3 +10,19 @@ window.APP_CONFIG = window.APP_CONFIG || {};
 // This can be overridden before this script runs by defining window.APP_CONFIG.CDN_BASE_URL.
 window.APP_CONFIG.CDN_BASE_URL = window.APP_CONFIG.CDN_BASE_URL || '';
 
+// Optional: Explicit URL to a samples manifest JSON. If not provided, defaults to
+// `${CDN_BASE_URL}/audio/samples/manifest.json` or `audio/samples/manifest.json` when CDN_BASE_URL is empty.
+window.APP_CONFIG.SAMPLES_MANIFEST_URL = window.APP_CONFIG.SAMPLES_MANIFEST_URL || (
+	window.APP_CONFIG.CDN_BASE_URL
+		? window.APP_CONFIG.CDN_BASE_URL.replace(/\/$/, '') + '/audio/samples/manifest.json'
+		: 'audio/samples/manifest.json'
+);
+
+// Optional: Explicit base folder URL for samples. Used to resolve relative entries in the manifest.
+// Defaults to `${CDN_BASE_URL}/audio/samples/` or `audio/samples/`.
+window.APP_CONFIG.SAMPLES_FOLDER_URL = window.APP_CONFIG.SAMPLES_FOLDER_URL || (
+	window.APP_CONFIG.CDN_BASE_URL
+		? window.APP_CONFIG.CDN_BASE_URL.replace(/\/$/, '') + '/audio/samples/'
+		: 'audio/samples/'
+);
+

--- a/js/game.js
+++ b/js/game.js
@@ -155,7 +155,7 @@ class SuperfreqGame {
             this.showLoading();
             
             // Get today's puzzle
-            this.currentPuzzle = this.puzzleSystem.getTodaysPuzzle();
+            this.currentPuzzle = await this.puzzleSystem.getTodaysPuzzle();
             
             if (!this.currentPuzzle) {
                 throw new Error('No puzzle found for today');

--- a/js/puzzles.js
+++ b/js/puzzles.js
@@ -91,6 +91,13 @@ class PuzzleSystem {
 
         // Sample puzzle data for development
         this.samplePuzzles = this.generateSamplePuzzles();
+
+        // Manifest-driven samples (loaded asynchronously)
+        this.samples = [];
+        this.samplesReady = false;
+        this.samplesError = null;
+        this.puzzleCache = {};
+        this.samplesPromise = this.loadSamplesManifest();
     }
 
     /**
@@ -156,6 +163,112 @@ class PuzzleSystem {
         }
         
         return puzzles;
+    }
+
+    /**
+     * Load samples manifest from CDN or relative folder.
+     * Supports either an array of strings or an object with a `files` array.
+     */
+    async loadSamplesManifest() {
+        const manifestUrl = (window.APP_CONFIG && window.APP_CONFIG.SAMPLES_MANIFEST_URL) ? window.APP_CONFIG.SAMPLES_MANIFEST_URL : 'audio/samples/manifest.json';
+        try {
+            const response = await fetch(manifestUrl, { cache: 'no-cache' });
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status}`);
+            }
+            const manifest = await response.json();
+            const normalized = this.normalizeManifest(manifest);
+            this.samples = normalized;
+            this.samplesReady = true;
+            return this.samples;
+        } catch (error) {
+            console.warn('Failed to load samples manifest, falling back:', error.message);
+            this.samples = [];
+            this.samplesReady = true;
+            this.samplesError = error;
+            return this.samples;
+        }
+    }
+
+    /**
+     * Normalize manifest content to an array of absolute URLs.
+     */
+    normalizeManifest(manifest) {
+        const folderBase = (window.APP_CONFIG && window.APP_CONFIG.SAMPLES_FOLDER_URL) ? window.APP_CONFIG.SAMPLES_FOLDER_URL : 'audio/samples/';
+        const toUrl = (entry) => this.resolveSampleUrl(folderBase, String(entry));
+
+        let entries = [];
+        if (Array.isArray(manifest)) {
+            entries = manifest;
+        } else if (manifest && Array.isArray(manifest.files)) {
+            entries = manifest.files;
+        } else {
+            console.warn('Unrecognized manifest format. Expected array or { files: [] }');
+            entries = [];
+        }
+
+        const audioExtensionRegex = /\.(wav|mp3|ogg|flac)(\?.*)?$/i;
+        const urls = entries
+            .map((e) => toUrl(e))
+            .filter((url) => audioExtensionRegex.test(url));
+
+        // De-duplicate while preserving order
+        const seen = new Set();
+        const uniqueUrls = [];
+        for (const url of urls) {
+            if (!seen.has(url)) {
+                seen.add(url);
+                uniqueUrls.push(url);
+            }
+        }
+        return uniqueUrls;
+    }
+
+    /**
+     * Resolve a manifest entry to an absolute URL.
+     */
+    resolveSampleUrl(baseFolderUrl, entry) {
+        if (!entry) return '';
+        const trimmed = entry.trim();
+        if (/^(https?:)?\/\//i.test(trimmed)) return trimmed; // Absolute URL
+        if (trimmed.startsWith('/')) {
+            // Absolute path on same origin - keep as-is
+            return trimmed;
+        }
+        const base = String(baseFolderUrl || 'audio/samples/').replace(/\/$/, '');
+        return `${base}/${trimmed}`;
+    }
+
+    /**
+     * Deterministic 32-bit FNV-1a hash of a string
+     */
+    deterministicHash(input) {
+        let hash = 0x811c9dc5;
+        for (let i = 0; i < input.length; i++) {
+            hash ^= input.charCodeAt(i);
+            hash += (hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24);
+        }
+        // Convert to unsigned 32-bit
+        return hash >>> 0;
+    }
+
+    /**
+     * Deterministically select an index in [0, count) from a date and salt
+     */
+    chooseDailyIndex(count, date, salt) {
+        if (!count || count <= 0) return 0;
+        const dateKey = this.formatDate(date);
+        const seed = this.deterministicHash(`${dateKey}:${salt}`);
+        return seed % count;
+    }
+
+    /**
+     * Deterministically generate a floating number in [0, 1) from date+salt
+     */
+    randomUnitFromDate(date, salt) {
+        const idx = this.deterministicHash(`${this.formatDate(date)}::${salt}`);
+        // Map 32-bit int to [0,1)
+        return (idx & 0xffffffff) / 0x100000000;
     }
 
     /**
@@ -226,16 +339,84 @@ class PuzzleSystem {
     /**
      * Get puzzle for a specific date
      */
-    getPuzzleForDate(date) {
+    async getPuzzleForDate(date) {
         const dateKey = this.formatDate(date);
-        return this.samplePuzzles[dateKey] || null;
+        if (this.puzzleCache[dateKey]) return this.puzzleCache[dateKey];
+
+        // Ensure samples manifest is loaded
+        try {
+            if (!this.samplesReady) {
+                await this.samplesPromise;
+            }
+        } catch (_) {
+            // Ignore; we'll handle empty samples below
+        }
+
+        const effectTypes = Object.keys(this.effects);
+        const effectIndex = this.chooseDailyIndex(effectTypes.length, date, 'effect');
+        const effectType = effectTypes[effectIndex];
+        const effect = this.effects[effectType];
+
+        // Deterministic correct value generation
+        let correctValue;
+        const u = this.randomUnitFromDate(date, 'value');
+        if (effect.logarithmic) {
+            const logMin = Math.log(effect.minValue);
+            const logMax = Math.log(effect.maxValue);
+            const logValue = logMin + u * (logMax - logMin);
+            correctValue = Math.exp(logValue);
+            correctValue = Math.round(correctValue);
+        } else {
+            correctValue = effect.minValue + u * (effect.maxValue - effect.minValue);
+            if (effect.unit === '%' || effect.unit === 'ms') {
+                correctValue = Math.round(correctValue);
+            } else {
+                correctValue = Math.round(correctValue * 100) / 100;
+            }
+        }
+
+        const effectPresets = this.generateEffectPresets(effectType);
+
+        // Select a sample deterministically from the manifest list if available
+        let drySampleUrl = '';
+        if (Array.isArray(this.samples) && this.samples.length > 0) {
+            const sampleIndex = this.chooseDailyIndex(this.samples.length, date, 'sample');
+            drySampleUrl = this.samples[sampleIndex];
+        } else {
+            // Fallback: keep old dev filename pattern; AudioManager will synthesize if not found
+            const sampleTypes = ['strings', 'drums', 'vocals', 'guitar', 'synth', 'bass'];
+            const fallbackIndex = this.chooseDailyIndex(sampleTypes.length, date, 'fallback');
+            const sampleName = sampleTypes[fallbackIndex];
+            const base = (window.APP_CONFIG && window.APP_CONFIG.CDN_BASE_URL) ? window.APP_CONFIG.CDN_BASE_URL.replace(/\/$/, '') + '/' : '';
+            drySampleUrl = `${base}audio/samples/${sampleName}_day001.wav`;
+        }
+
+        const puzzle = {
+            date: dateKey,
+            effectType: effectType,
+            effectName: effect.name,
+            description: effect.description,
+            parameter: effect.parameter,
+            parameterName: effect.parameter,
+            correctValue: correctValue,
+            minValue: effect.minValue,
+            maxValue: effect.maxValue,
+            unit: effect.unit,
+            sampleType: 'audio',
+            drySample: drySampleUrl,
+            livesAllocated: this.getRecommendedLives(effectType),
+            effectPresets: effectPresets
+        };
+
+        this.puzzleCache[dateKey] = puzzle;
+        return puzzle;
     }
 
     /**
      * Get today's puzzle
      */
-    getTodaysPuzzle() {
-        return this.getPuzzleForDate(new Date());
+    async getTodaysPuzzle() {
+        return await this.getPuzzleForDate(new Date());
     }
 
     /**


### PR DESCRIPTION
Add manifest-driven daily sample selection to support arbitrary CDN filenames.

This allows audio files to be uploaded to a CDN folder with any names, listed in a `manifest.json`. The game deterministically selects a daily sample from this list, eliminating the need for date-based filename conventions.

---
<a href="https://cursor.com/background-agent?bcId=bc-eaf89744-019a-4498-a821-eac051f13b11">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eaf89744-019a-4498-a821-eac051f13b11">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

