### PR TITLE
Fetch only vocals_day001.wav for testing

### DIFF
--- a/js/audio.js
+++ b/js/audio.js
@@ -60,8 +60,10 @@ class AudioManager {
             // Try to load dry sample, fallback to generated audio if file not found
             let success = false;
             try {
-                // Check if the URL is accessible first
-                const response = await fetch(puzzleData.drySample);
+                // Check if the URL is accessible first (temporarily force a single test file)
+                const baseUrl = (window.APP_CONFIG && window.APP_CONFIG.CDN_BASE_URL) ? window.APP_CONFIG.CDN_BASE_URL.replace(/\/$/, '') + '/' : '';
+                const forcedUrl = `${baseUrl}audio/samples/vocals_day001.wav`;
+                const response = await fetch(forcedUrl);
                 if (!response.ok) {
                     throw new Error(`HTTP ${response.status}: ${response.statusText}`);
                 }

--- a/js/audio.js
+++ b/js/audio.js
@@ -63,6 +63,7 @@ class AudioManager {
                 // Check if the URL is accessible first (temporarily force a single test file)
                 const baseUrl = (window.APP_CONFIG && window.APP_CONFIG.CDN_BASE_URL) ? window.APP_CONFIG.CDN_BASE_URL.replace(/\/$/, '') + '/' : '';
                 const forcedUrl = `${baseUrl}audio/samples/vocals_day001.wav`;
+                // const response = await fetch(puzzleData.drySample);
                 const response = await fetch(forcedUrl);
                 if (!response.ok) {
                     throw new Error(`HTTP ${response.status}: ${response.statusText}`);


### PR DESCRIPTION
Temporarily force the game to fetch only `vocals_day001.wav` for testing purposes.

---
<a href="https://cursor.com/background-agent?bcId=bc-706516c6-58c6-465a-9642-6c30b30f537a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-706516c6-58c6-465a-9642-6c30b30f537a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

