### PR TITLE
Investigate bunny cdn free tier and setup

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -8,5 +8,5 @@ window.APP_CONFIG = window.APP_CONFIG || {};
 
 // CDN base URL for static assets (e.g., audio files). Leave empty for relative paths.
 // This can be overridden before this script runs by defining window.APP_CONFIG.CDN_BASE_URL.
-window.APP_CONFIG.CDN_BASE_URL = window.APP_CONFIG.CDN_BASE_URL || '';
+window.APP_CONFIG.CDN_BASE_URL = window.APP_CONFIG.CDN_BASE_URL || 'https://cdn.superfreq.xyz';
 


### PR DESCRIPTION
Set the default CDN base URL to `https://cdn.superfreq.xyz` to integrate the Bunny.net CDN.

---
<a href="https://cursor.com/background-agent?bcId=bc-72d7c11b-c42e-4d74-ba59-cb838d2302b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-72d7c11b-c42e-4d74-ba59-cb838d2302b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

