### PR TITLE
Fix game logic based on puzzle hidden parameter

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -225,9 +225,6 @@ class SuperfreqGame {
         
         this.userGuess = value;
         this.updateParameterDisplay(value);
-        
-        // Update the audio effect in real-time
-        this.audioManager.updateMainParameter(value);
     }
 
     /**


### PR DESCRIPTION
Effected audio playback now uses the puzzle's hidden correct value, not the player's current guess.

---
<a href="https://cursor.com/background-agent?bcId=bc-bf4b7049-1423-437c-aba6-7eae94d7f88e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bf4b7049-1423-437c-aba6-7eae94d7f88e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

