### PR TITLE
Revamp gui to ssl plugin style

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1046,3 +1046,68 @@ a {
     background: #30e07c;
     box-shadow: 0 0 10px rgba(48,224,124,0.7), 0 0 0 2px rgba(0,0,0,0.6);
 }
+
+/* =============================
+   Transport & Plugin Controls
+   ============================= */
+.transport {
+    display: flex;
+    gap: 0.75rem;
+    align-items: center;
+    margin-bottom: 1rem;
+}
+
+.transport-button, .toggle-button {
+    background: var(--panel-alt);
+    color: var(--text);
+    border: 1px solid var(--border);
+    padding: 0.6rem 1rem;
+    border-radius: 8px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s ease, transform 0.1s ease, box-shadow 0.2s ease;
+}
+
+.transport-button:hover, .toggle-button:hover {
+    background: #243040;
+}
+
+.toggle-button[aria-pressed="true"] {
+    background: #382b2b;
+    border-color: #4a2f2f;
+}
+
+.plugin-controls {
+    display: flex;
+    align-items: stretch;
+    gap: 1.25rem;
+    margin-bottom: 1rem;
+}
+
+.fixed-parameters {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(90px, 1fr));
+    gap: 1rem;
+}
+
+.fixed-knob {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.4rem;
+}
+
+.knob-readonly {
+    cursor: default;
+}
+
+.knob-caption {
+    font-size: 0.8rem;
+    color: var(--muted);
+}
+
+.knob-value {
+    font-family: 'Roboto Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    font-size: 0.9rem;
+    color: var(--text);
+}

--- a/index.html
+++ b/index.html
@@ -37,24 +37,21 @@
                         <p id="effect-description"></p>
                     </div>
 
-                    <div id="audio-section">
-                        <div id="dry-sample">
-                            <h3>Dry</h3>
-                            <button id="dry-audio" class="audio-button" data-tooltip="Play original">
-                                ▶︎ Dry
-                            </button>
-                        </div>
-
-                        <div id="effected-sample">
-                            <h3>FX</h3>
-                            <button id="effected-audio" class="audio-button" data-tooltip="Play with current setting">
-                                ▶︎ FX
-                            </button>
-                        </div>
+                    <div id="transport" class="transport">
+                        <button id="play-pause-button" class="transport-button" data-tooltip="Play/Pause">
+                            ▶︎ Play
+                        </button>
+                        <button id="bypass-button" class="toggle-button" aria-pressed="false" data-tooltip="Bypass effect">
+                            Bypass Off
+                        </button>
                     </div>
 
                     <div id="guess-section">
                         <h3>Set</h3>
+                        <div id="plugin-controls" class="plugin-controls">
+                            <div id="fixed-parameters" class="fixed-parameters" aria-label="Fixed parameters"></div>
+                        </div>
+
                         <div id="parameter-input">
                             <label for="parameter-slider" id="parameter-label"></label>
                             <div class="control-row">

--- a/js/effects.js
+++ b/js/effects.js
@@ -152,6 +152,7 @@ class AudioEffectsEngine {
                 console.log('Audio playback ended');
                 this.isPlaying = false;
                 this.currentSource = null;
+                try { window.dispatchEvent(new CustomEvent('audio-playback-ended')); } catch (e) {}
             };
 
             console.log('Audio playback started successfully');


### PR DESCRIPTION
Refactor the UI into an SSL-inspired plugin interface, unifying transport controls with play/pause and bypass, and displaying fixed effect parameters as unmovable knobs.

---
<a href="https://cursor.com/background-agent?bcId=bc-98ba4627-8989-4bdc-89fc-a7824c9a0475">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-98ba4627-8989-4bdc-89fc-a7824c9a0475">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

