### PR TITLE
Revamp gui to ssl plugin style

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -291,6 +291,52 @@ main {
     box-shadow: none;
 }
 
+/* Transport row (SSL-inspired) */
+.transport-row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+    background: #0f131a;
+    border-radius: 10px;
+    border: 1px solid rgba(255,255,255,0.06);
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.04), inset 0 -1px 0 rgba(0,0,0,0.5);
+    margin-bottom: 1.25rem;
+}
+
+.transport-button {
+    background: #2e8b57;
+    color: white;
+    border: 1px solid rgba(0,0,0,0.4);
+    padding: 0.65rem 1.25rem;
+    border-radius: 10px;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    cursor: pointer;
+    box-shadow: 0 6px 18px rgba(46, 139, 87, 0.35);
+}
+
+.transport-button:hover { background: #277a4c; }
+
+.bypass-button {
+    background: #3a4250;
+    color: #e5e7eb;
+    border: 1px solid rgba(0,0,0,0.5);
+    padding: 0.65rem 1rem;
+    border-radius: 10px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    cursor: pointer;
+    box-shadow: 0 6px 18px rgba(0,0,0,0.3);
+}
+
+.bypass-button[aria-pressed="true"] {
+    background: #6b7280;
+    color: #111827;
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.2);
+}
+
 .audition-tip {
     color: #856404;
     font-size: 0.9rem;
@@ -982,6 +1028,54 @@ a {
 }
 
 .parameter-display { margin-top: 0.25rem; }
+
+/* Plugin control layout */
+.plugin-controls {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1.25rem;
+}
+
+.knob-strip {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+    gap: 1rem;
+    padding: 0.75rem;
+    background: #0c1117;
+    border-radius: 10px;
+    border: 1px solid rgba(255,255,255,0.06);
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.04), inset 0 -1px 0 rgba(0,0,0,0.5);
+}
+
+.main-parameter {
+    padding: 0.75rem;
+    background: #0c1117;
+    border-radius: 10px;
+    border: 1px solid rgba(255,255,255,0.06);
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.04), inset 0 -1px 0 rgba(0,0,0,0.5);
+}
+
+.knob-group.static .knob {
+    cursor: default;
+    pointer-events: none;
+    filter: saturate(0.85);
+}
+
+.knob-group.static .knob-labels {
+    justify-content: center;
+    gap: 0.5rem;
+}
+
+.param-chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.25rem 0.5rem;
+    background: #111827;
+    border: 1px solid rgba(255,255,255,0.06);
+    border-radius: 8px;
+    color: #e5e7eb;
+    font-size: 0.85rem;
+}
 
 /* Theme overrides for knob */
 .theme-dark .knob {

--- a/index.html
+++ b/index.html
@@ -37,38 +37,34 @@
                         <p id="effect-description"></p>
                     </div>
 
-                    <div id="audio-section">
-                        <div id="dry-sample">
-                            <h3>Dry</h3>
-                            <button id="dry-audio" class="audio-button" data-tooltip="Play original">
-                                ▶︎ Dry
-                            </button>
-                        </div>
-
-                        <div id="effected-sample">
-                            <h3>FX</h3>
-                            <button id="effected-audio" class="audio-button" data-tooltip="Play with current setting">
-                                ▶︎ FX
-                            </button>
-                        </div>
+                    <div id="transport" class="transport-row">
+                        <button id="play-pause" class="transport-button" data-tooltip="Play or pause audio">
+                            ▶︎ Play
+                        </button>
+                        <button id="bypass-toggle" class="bypass-button" aria-pressed="false" data-tooltip="Bypass effect processing">
+                            Bypass
+                        </button>
                     </div>
 
                     <div id="guess-section">
-                        <h3>Set</h3>
-                        <div id="parameter-input">
-                            <label for="parameter-slider" id="parameter-label"></label>
-                            <div class="control-row">
-                                <div class="knob-group">
-                                    <div class="knob" id="parameter-knob" role="slider" aria-label="Parameter knob" aria-valuemin="0" aria-valuemax="100" aria-valuenow="50" tabindex="0"></div>
-                                    <div class="knob-labels">
-                                        <span class="min-label"></span>
-                                        <span class="max-label"></span>
+                        <h3>Controls</h3>
+                        <div class="plugin-controls">
+                            <div id="fixed-params" class="knob-strip" aria-label="Fixed parameters"></div>
+                            <div id="parameter-input" class="main-parameter">
+                                <label for="parameter-slider" id="parameter-label"></label>
+                                <div class="control-row">
+                                    <div class="knob-group">
+                                        <div class="knob" id="parameter-knob" role="slider" aria-label="Parameter knob" aria-valuemin="0" aria-valuemax="100" aria-valuenow="50" tabindex="0"></div>
+                                        <div class="knob-labels">
+                                            <span class="min-label"></span>
+                                            <span class="max-label"></span>
+                                        </div>
                                     </div>
-                                </div>
-                                <input class="visually-hidden" type="range" id="parameter-slider" min="0" max="100" step="1">
-                                <div class="parameter-display">
-                                    <span id="parameter-value"></span>
-                                    <span id="parameter-unit"></span>
+                                    <input class="visually-hidden" type="range" id="parameter-slider" min="0" max="100" step="1">
+                                    <div class="parameter-display">
+                                        <span id="parameter-value"></span>
+                                        <span id="parameter-unit"></span>
+                                    </div>
                                 </div>
                             </div>
                         </div>

--- a/js/audio.js
+++ b/js/audio.js
@@ -15,6 +15,7 @@ class AudioManager {
         // Audio state
         this.isPlaying = false;
         this.currentSource = null;
+        this.onPlaybackEnded = null;
         
         // Initialize audio context and effects engine
         this.initAudioContext();
@@ -194,6 +195,9 @@ class AudioManager {
             source.onended = () => {
                 this.isPlaying = false;
                 this.currentSource = null;
+                if (typeof this.onPlaybackEnded === 'function') {
+                    try { this.onPlaybackEnded(); } catch (e) { /* noop */ }
+                }
             };
 
             console.log('Playing dry sample');

--- a/js/effects.js
+++ b/js/effects.js
@@ -10,6 +10,7 @@ class AudioEffectsEngine {
         this.currentEffectChain = null;
         this.drySampleBuffer = null;
         this.isPlaying = false;
+        this.isBypassed = false;
         
         this.initEffects();
     }
@@ -134,9 +135,13 @@ class AudioEffectsEngine {
                 numberOfChannels: this.drySampleBuffer.numberOfChannels
             });
 
-            // Connect through effect chain
-            source.connect(this.currentEffectChain.input);
-            this.currentEffectChain.output.connect(this.audioContext.destination);
+            // Connect either through effect chain or directly if bypassed
+            if (this.isBypassed || !this.currentEffectChain) {
+                source.connect(this.audioContext.destination);
+            } else {
+                source.connect(this.currentEffectChain.input);
+                this.currentEffectChain.output.connect(this.audioContext.destination);
+            }
 
             console.log('Audio nodes connected successfully');
 
@@ -183,6 +188,13 @@ class AudioEffectsEngine {
             }
             this.currentEffectChain = null;
         }
+    }
+
+    /**
+     * Toggle bypass state
+     */
+    setBypass(enabled) {
+        this.isBypassed = !!enabled;
     }
 
     /**


### PR DESCRIPTION
Refactor the audio playback and parameter controls into a VST-style plugin interface with a single play/pause, bypass, and static parameter knobs.

---
<a href="https://cursor.com/background-agent?bcId=bc-25554024-4769-46e9-a52a-94a1b0609275">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-25554024-4769-46e9-a52a-94a1b0609275">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

