### PR TITLE
Bypass button should not play sample

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -245,10 +245,9 @@ class SuperfreqGame {
         if (!this.elements.bypass) return;
         this.elements.bypass.setAttribute('aria-pressed', enabled ? 'true' : 'false');
         this.elements.bypass.textContent = enabled ? 'Bypass On' : 'Bypass Off';
-        // If currently playing, restart appropriate stream to reflect bypass state
+        // If currently playing, stop playback; do not auto-start
         if (this.audioManager.isPlaying) {
             this.togglePlayPause(); // stop
-            this.togglePlayPause(); // start with new state
         }
     }
 


### PR DESCRIPTION
Modify bypass toggle to only stop playback, preventing unintended sample restarts.

---
<a href="https://cursor.com/background-agent?bcId=bc-052cf601-f754-4e71-b01c-fc7e612797be">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-052cf601-f754-4e71-b01c-fc7e612797be">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

