### PR TITLE
Improve gui style with plugin example

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -9,7 +9,7 @@ body {
     font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
     line-height: 1.6;
     color: #333;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: linear-gradient(135deg, #11151c 0%, #0c1016 100%);
     min-height: 100vh;
 }
 
@@ -51,11 +51,11 @@ main {
 }
 
 #game-container {
-    background: white;
-    border-radius: 20px;
+    background: #11151c;
+    border-radius: 16px;
     padding: 2rem;
-    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.1);
-    backdrop-filter: blur(10px);
+    box-shadow: 0 22px 50px rgba(0, 0, 0, 0.55);
+    border: 1px solid rgba(255,255,255,0.04);
 }
 
 /* Game sections */
@@ -63,6 +63,20 @@ main {
     margin-bottom: 2rem;
     padding-bottom: 1rem;
     border-bottom: 2px solid #f0f0f0;
+}
+
+/* Module headings like a console strip */
+.theme-dark #puzzle-info::before,
+.theme-dark #guess-section::before,
+.theme-dark #results::before {
+    content: attr(data-module) "";
+    content: attr(data-module);
+    display: block;
+    font-size: 0.7rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--muted);
+    margin-bottom: 0.5rem;
 }
 
 /* Compact header row for title + lives */
@@ -660,8 +674,22 @@ a {
 .theme-dark #game-container {
 	background: var(--panel);
 	border: 1px solid var(--border);
-	box-shadow: 0 20px 50px rgba(0, 0, 0, 0.45);
+	box-shadow: 0 30px 70px rgba(0, 0, 0, 0.55);
+	position: relative;
 }
+
+.theme-dark #game-container::before,
+.theme-dark #game-container::after {
+	content: '';
+	position: absolute;
+	left: 8px;
+	right: 8px;
+	height: 2px;
+	background: linear-gradient(90deg, transparent, rgba(255,255,255,0.06), transparent);
+}
+
+.theme-dark #game-container::before { top: 10px; }
+.theme-dark #game-container::after { bottom: 10px; }
 
 .theme-dark #puzzle-info {
 	border-bottom: 1px solid var(--border);
@@ -891,7 +919,7 @@ a {
     width: var(--size);
     height: var(--size);
     border-radius: 50%;
-    background: radial-gradient(circle at 30% 30%, #3a4250 0%, #222832 60%, #1a1f27 100%);
+    background: radial-gradient(circle at 30% 30%, #495264 0%, #242a34 58%, #1a1f27 100%);
     border: 1px solid rgba(0,0,0,0.6);
     position: relative;
     box-shadow: inset 0 8px 20px rgba(255,255,255,0.08), inset 0 -10px 30px rgba(0,0,0,0.6), 0 10px 24px rgba(0,0,0,0.45);
@@ -913,7 +941,7 @@ a {
     top: 50%;
     width: 6px;
     height: 26px;
-    background: linear-gradient(180deg, #c5d2e8 0%, #8fa2c2 100%);
+    background: linear-gradient(180deg, #e2eaf7 0%, #9eb3d3 100%);
     border-radius: 3px;
     transform-origin: 50% 38px;
     transform: translate(-50%, -38px) rotate(var(--knob-rotation));
@@ -925,7 +953,7 @@ a {
     position: absolute;
     inset: 10px;
     border-radius: 50%;
-    box-shadow: inset 0 1px 0 rgba(255,255,255,0.08), inset 0 -2px 6px rgba(0,0,0,0.6);
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.08), inset 0 -2px 6px rgba(0,0,0,0.6), 0 0 0 1px rgba(255,255,255,0.02);
 }
 
 .knob-labels {
@@ -948,7 +976,7 @@ a {
 
 /* Theme overrides for knob */
 .theme-dark .knob {
-    background: radial-gradient(circle at 30% 30%, #3a4250 0%, #1e2530 60%, #151a21 100%);
+    background: radial-gradient(circle at 30% 30%, #495264 0%, #1e2530 60%, #151a21 100%);
     border-color: rgba(255,255,255,0.05);
 }
 
@@ -1000,14 +1028,14 @@ a {
 .plugin-header .led {
     width: 10px; height: 10px;
     border-radius: 50%;
-    background: #24313f;
-    box-shadow: 0 0 0 2px rgba(0,0,0,0.5), inset 0 -1px 2px rgba(0,0,0,0.5);
+    background: radial-gradient(circle at 30% 30%, #1f2a37 0%, #111923 80%);
+    box-shadow: 0 0 0 2px rgba(0,0,0,0.6), inset 0 -1px 2px rgba(0,0,0,0.6);
 }
 
 .theme-dark .plugin-header .brand { color: var(--muted); }
 .theme-dark .plugin-header .led.on {
-    background: #30e07c;
-    box-shadow: 0 0 10px rgba(48,224,124,0.7), 0 0 0 2px rgba(0,0,0,0.6);
+    background: radial-gradient(circle at 40% 35%, #67ffb0 0%, #30e07c 40%, #0c2a1a 90%);
+    box-shadow: 0 0 14px rgba(48,224,124,0.9), 0 0 0 2px rgba(0,0,0,0.7), inset 0 0 6px rgba(255,255,255,0.35);
 }
 
 /* =============================
@@ -1036,8 +1064,25 @@ a {
 }
 
 .toggle-button[aria-pressed="true"] {
-    background: #382b2b;
-    border-color: #4a2f2f;
+    background: radial-gradient(120% 120% at 30% 30%, #412a2a, #231a1a 70%);
+    border-color: #563030;
+    box-shadow: 0 0 0 1px rgba(255,0,0,0.06) inset, 0 0 20px rgba(255, 64, 64, 0.15);
+}
+
+.transport-button::before,
+.toggle-button::before {
+    content: '';
+    display: inline-block;
+    width: 8px; height: 8px;
+    border-radius: 50%;
+    margin-right: 8px;
+    background: #2a3342;
+    box-shadow: inset 0 -1px 1px rgba(0,0,0,0.6);
+}
+
+.toggle-button[aria-pressed="true"]::before {
+    background: #ff4d4d;
+    box-shadow: 0 0 10px rgba(255,77,77,0.6), inset 0 -1px 1px rgba(0,0,0,0.6);
 }
 
 .plugin-controls {

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
                 <div id="loading" class="hidden" aria-live="polite">Loading…</div>
 
                 <div id="game" class="hidden">
-                    <div id="puzzle-info">
+                    <div id="puzzle-info" data-module="Info">
                         <div class="info-row">
                             <h2 id="effect-title">Challenge</h2>
                         </div>
@@ -45,7 +45,7 @@
                         </button>
                     </div>
 
-                    <div id="guess-section">
+                    <div id="guess-section" data-module="Set">
                         <h3>Set</h3>
                         <div id="plugin-controls" class="plugin-controls">
                             <div id="fixed-parameters" class="fixed-parameters" aria-label="Fixed parameters"></div>
@@ -55,7 +55,7 @@
                             <label for="parameter-slider" id="parameter-label"></label>
                             <div class="control-row">
                                 <div class="knob-group">
-                                    <div class="knob" id="parameter-knob" role="slider" aria-label="Parameter knob" aria-valuemin="0" aria-valuemax="100" aria-valuenow="50" tabindex="0"></div>
+                                    <div class="knob" id="parameter-knob" role="slider" aria-label="Parameter knob" aria-valuemin="0" aria-valuemax="100" aria-valuenow="50" tabindex="0"><div class="knob-ticks"></div></div>
                                     <div class="knob-labels">
                                         <span class="min-label"></span>
                                         <span class="max-label"></span>
@@ -78,7 +78,7 @@
                         <button id="submit-guess" class="submit-button" disabled data-tooltip="Lock in answer">Submit</button>
                     </div>
 
-                    <div id="results" class="hidden">
+                    <div id="results" class="hidden" data-module="Results">
                         <h3>Results</h3>
                         <div id="score-display" class="score-display"></div>
                         <div id="correct-answer" class="correct-answer"></div>


### PR DESCRIPTION
Implement a hardware-inspired channel strip GUI style, including module headings, LED buttons, container rails, and enhanced knobs.

---
<a href="https://cursor.com/background-agent?bcId=bc-2189b581-e408-46c3-90e2-f765a94ae7f6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2189b581-e408-46c3-90e2-f765a94ae7f6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

